### PR TITLE
Add label editing UI to member form

### DIFF
--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -216,7 +216,8 @@
       "lastName": "Nachname",
       "lastNamePlaceholder": "Nachname eingeben...",
       "firstName": "Vorname",
-      "firstNamePlaceholder": "Vorname eingeben..."
+      "firstNamePlaceholder": "Vorname eingeben...",
+      "labelPlaceholder": "Label hinzufügen..."
     },
     "editMember": {
       "title": "Mitglied bearbeiten",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -216,7 +216,8 @@
       "lastName": "Last Name",
       "firstName": "First Name",
       "lastNamePlaceholder": "Enter Last Name...",
-      "firstNamePlaceholder": "Enter First Name..."
+      "firstNamePlaceholder": "Enter First Name...",
+      "labelPlaceholder": "Add label..."
     },
     "editMember": {
       "title": "Edit Member",

--- a/src/routes/dashboard/members/MemberForm.svelte
+++ b/src/routes/dashboard/members/MemberForm.svelte
@@ -2,7 +2,7 @@
   import { modalStore } from '@skeletonlabs/skeleton';
   import { _ } from 'svelte-i18n';
   import Fa from 'svelte-fa';
-  import { faSpinner } from '@fortawesome/free-solid-svg-icons';
+  import { faSpinner, faXmark } from '@fortawesome/free-solid-svg-icons';
 
   export let lastname = '';
   export let firstname = '';
@@ -13,6 +13,8 @@
   export let isEditing = false;
   export let id = '';
 
+  let labelInput = '';
+
   let formData = {
     id,
     lastname,
@@ -21,6 +23,25 @@
     mobile,
     labels: labels || ['new']
   };
+
+  function addLabel() {
+    const value = labelInput.trim().toLowerCase();
+    if (value && !formData.labels.includes(value)) {
+      formData.labels = [...formData.labels, value];
+    }
+    labelInput = '';
+  }
+
+  function removeLabel(label: string) {
+    formData.labels = formData.labels.filter((l) => l !== label);
+  }
+
+  function handleLabelKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      addLabel();
+    }
+  }
 
   function cancel() {
     modalStore.close();
@@ -62,6 +83,33 @@
     <span>{$_('page.members.mobile')}</span>
     <input class="input" bind:value={formData.mobile} type="tel" placeholder="+41 79 123 45 67" />
   </label>
+  <div class="label">
+    <span>{$_('page.members.labels')}</span>
+    <div class="flex flex-wrap gap-1 mb-2">
+      {#each formData.labels as label (label)}
+        <button
+          type="button"
+          class="chip variant-filled-secondary flex items-center gap-1"
+          on:click={() => removeLabel(label)}
+        >
+          {label}
+          <Fa icon={faXmark} size="xs" />
+        </button>
+      {/each}
+    </div>
+    <div class="input-group input-group-divider grid-cols-[1fr_auto]">
+      <input
+        class="input"
+        bind:value={labelInput}
+        on:keydown={handleLabelKeydown}
+        type="text"
+        placeholder={$_('dialog.newMember.labelPlaceholder')}
+      />
+      <button type="button" class="variant-filled-secondary" on:click={addLabel}>
+        {$_('button.add')}
+      </button>
+    </div>
+  </div>
 </form>
 <footer class="modal-footer flex justify-end space-x-2">
   <button class="btn variant-ghost-surface" on:click={cancel}>{$_('button.cancel')}</button>


### PR DESCRIPTION
## Summary
- Add chip-based label input to MemberForm for creating and editing members
- Labels can be added via text input (Enter key or Add button) and removed by clicking the chip
- Duplicates are prevented and input is normalized to lowercase
- Added i18n keys for label placeholder in EN and DE

## Test plan
- [ ] Open "Add Member" form and verify labels section appears with default "new" label
- [ ] Type a label name and press Enter — verify it appears as a chip
- [ ] Click the X on a label chip — verify it is removed
- [ ] Try adding a duplicate label — verify it is not added twice
- [ ] Edit an existing member — verify existing labels are shown and can be modified
- [ ] Save and verify labels persist in the database and display on the detail/list pages

https://claude.ai/code/session_01Vp4uTk3AcFNfoFPCARQEKv