### PR TITLE
Redesign training detail page

### DIFF
--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -216,7 +216,8 @@
       "lastName": "Nachname",
       "lastNamePlaceholder": "Nachname eingeben...",
       "firstName": "Vorname",
-      "firstNamePlaceholder": "Vorname eingeben..."
+      "firstNamePlaceholder": "Vorname eingeben...",
+      "labelPlaceholder": "Label hinzufügen..."
     },
     "editMember": {
       "title": "Mitglied bearbeiten",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -216,7 +216,8 @@
       "lastName": "Last Name",
       "firstName": "First Name",
       "lastNamePlaceholder": "Enter Last Name...",
-      "firstNamePlaceholder": "Enter First Name..."
+      "firstNamePlaceholder": "Enter First Name...",
+      "labelPlaceholder": "Add label..."
     },
     "editMember": {
       "title": "Edit Member",

--- a/src/routes/dashboard/members/MemberForm.svelte
+++ b/src/routes/dashboard/members/MemberForm.svelte
@@ -2,7 +2,7 @@
   import { modalStore } from '@skeletonlabs/skeleton';
   import { _ } from 'svelte-i18n';
   import Fa from 'svelte-fa';
-  import { faSpinner } from '@fortawesome/free-solid-svg-icons';
+  import { faSpinner, faXmark } from '@fortawesome/free-solid-svg-icons';
 
   export let lastname = '';
   export let firstname = '';
@@ -13,6 +13,8 @@
   export let isEditing = false;
   export let id = '';
 
+  let labelInput = '';
+
   let formData = {
     id,
     lastname,
@@ -21,6 +23,25 @@
     mobile,
     labels: labels || ['new']
   };
+
+  function addLabel() {
+    const value = labelInput.trim().toLowerCase();
+    if (value && !formData.labels.includes(value)) {
+      formData.labels = [...formData.labels, value];
+    }
+    labelInput = '';
+  }
+
+  function removeLabel(label: string) {
+    formData.labels = formData.labels.filter((l) => l !== label);
+  }
+
+  function handleLabelKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter') {
+      event.preventDefault();
+      addLabel();
+    }
+  }
 
   function cancel() {
     modalStore.close();
@@ -62,6 +83,33 @@
     <span>{$_('page.members.mobile')}</span>
     <input class="input" bind:value={formData.mobile} type="tel" placeholder="+41 79 123 45 67" />
   </label>
+  <div class="label">
+    <span>{$_('page.members.labels')}</span>
+    <div class="flex flex-wrap gap-1 mb-2">
+      {#each formData.labels as label (label)}
+        <button
+          type="button"
+          class="chip variant-filled-secondary flex items-center gap-1"
+          on:click={() => removeLabel(label)}
+        >
+          {label}
+          <Fa icon={faXmark} size="xs" />
+        </button>
+      {/each}
+    </div>
+    <div class="input-group input-group-divider grid-cols-[1fr_auto]">
+      <input
+        class="input"
+        bind:value={labelInput}
+        on:keydown={handleLabelKeydown}
+        type="text"
+        placeholder={$_('dialog.newMember.labelPlaceholder')}
+      />
+      <button type="button" class="variant-filled-secondary" on:click={addLabel}>
+        {$_('button.add')}
+      </button>
+    </div>
+  </div>
 </form>
 <footer class="modal-footer flex justify-end space-x-2">
   <button class="btn variant-ghost-surface" on:click={cancel}>{$_('button.cancel')}</button>

--- a/src/routes/dashboard/trainings/[trainingId]/[date]/+page.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/[date]/+page.svelte
@@ -9,7 +9,9 @@
     faArrowRight,
     faExclamationTriangle,
     faClipboardList,
-    faUsers
+    faUsers,
+    faUserCheck,
+    faChalkboardTeacher
   } from '@fortawesome/free-solid-svg-icons';
   import dayjs from 'dayjs';
   import { goto } from '$app/navigation';
@@ -43,11 +45,11 @@
 
     filteredData = filteredData.sort((a, b) => {
       if (a.isPresent && !b.isPresent) {
-        return -1; // a comes first
+        return -1;
       } else if (!a.isPresent && b.isPresent) {
-        return 1; // b comes first
+        return 1;
       } else {
-        return 0; // no sorting needed
+        return 0;
       }
     });
   };
@@ -72,7 +74,6 @@
     data.participants[index].trainerRole = trainerRole;
     clearSearch();
 
-    // Always delete any existing entry (code simplicity to the tradeoff of executing 2 api calls)
     const { error } = await supabaseClient
       .from('logs')
       .delete()
@@ -99,7 +100,7 @@
   async function addParticipant(event: CustomEvent<{ member: MMember }>) {
     const foundIndex = filteredData.findIndex((item) => item.id === event.detail.member.id);
     if (foundIndex > -1) {
-      return; // member already there
+      return;
     }
     const d = await supabaseClient
       .from('participants')
@@ -111,7 +112,7 @@
       data.participants.push(d.data.members as unknown as MMember);
     }
     _changePresence(event.detail.member, true, 'attendee');
-    filterData(); // force reactivity
+    filterData();
   }
 
   async function removeParticipant(event: CustomEvent<{ member: MMember; checked: boolean }>) {
@@ -120,11 +121,10 @@
       .delete()
       .eq('trainingId', data.trainingId)
       .eq('memberId', event.detail.member.id);
-    // TODO: Splice , would disappear if subscribed to supabase
     const index = data.participants.findIndex((p) => p.id === event.detail.member.id);
     if (index > -1) {
       data.participants.splice(index, 1);
-      filterData(); // force reactivity
+      filterData();
     }
   }
 
@@ -158,90 +158,129 @@
   function toggleView() {
     showLessonPlan = !showLessonPlan;
   }
+
+  $: formattedDate = dayjs(data.date, 'YYYY-MM-DD').format('DD. MMMM YYYY');
 </script>
 
-<div class="flex justify-between items-center">
-  <div>
-    <h2>{data.title}</h2>
-    <h4>{$_('weekday.' + data.weekday)} {data.dateFrom} | {data.section}</h4>
-  </div>
-  <button class="btn variant-outline-primary flex items-center gap-2" on:click={toggleView}>
-    <Fa icon={showLessonPlan ? faUsers : faClipboardList} />
-    <span>{showLessonPlan ? $_('page.trainings.attendance') : $_('page.trainings.lessonPlan')}</span
-    >
-  </button>
-</div>
-<hr class="my-2" />
-<div class="flex justify-between items-center my-2">
-  <div>
-    <button class="btn" on:click={previousWeek}>
-      <Fa icon={faArrowLeft} /><span>{$_('button.week')}</span>
-    </button>
-  </div>
-  <div>
-    <h2>{data.date}</h2>
-  </div>
-  <div>
-    <button class="btn" on:click={nextWeek}>
-      <span>{$_('button.week')}</span><Fa icon={faArrowRight} />
-    </button>
-  </div>
-</div>
-{#if !showLessonPlan}
-  <div>
+<!-- Header card -->
+<div class="card p-4 mb-4">
+  <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
     <div>
-      <div class="flex items-center">
-        <div class="mr-2">
-          <span class="chip variant-filled-secondary">{presentParticipants.length}</span>
-        </div>
-        <div class="grow">
-          <input
-            class="input"
-            on:keydown={navigateList}
-            type="text"
-            placeholder={$_('page.trainings.searchMembersPlaceholder')}
-            bind:value={searchterm}
-            on:input={filterData}
-            on:focus={() => (animateList = false)}
-            on:blur={() => (animateList = true)}
-          />
-        </div>
+      <h2 class="h2">{data.title}</h2>
+      <div class="flex items-center gap-2 mt-1">
+        <span class="badge variant-filled-secondary">{data.section}</span>
+        <span class="text-sm opacity-70">
+          {$_('weekday.' + data.weekday)} | {data.dateFrom}
+        </span>
       </div>
-
-      <!-- Trainer Warning Alert -->
-      {#if presentParticipants.length > 0 && !hasMainTrainer}
-        <aside class="alert variant-ghost-warning my-2">
-          <div><Fa icon={faExclamationTriangle} class="text-warning-500" /></div>
-          <div class="alert-message">
-            <p>
-              <span class="font-bold">{$_('page.trainings.noMainTrainerWarning.title')}</span>
-              {$_('page.trainings.noMainTrainerWarning.message')}
-            </p>
-          </div>
-        </aside>
-      {/if}
-      <ul class="list">
-        {#each filteredData as p, i (p.id)}
-          <div
-            class="item"
-            animate:flip={{ delay: 0, duration: animateList ? 400 : 0, easing: quintInOut }}
-          >
-            <ParticipantCard
-              highlight={hiIndex === i}
-              member={p}
-              on:change={changePresence}
-              on:remove={removeParticipant}
-            />
-          </div>
-        {/each}
-        <li>
-          <aside class="alert variant-ghost-tertiary w-full justify-items-center">
-            <AddParticipantInputBox on:add={addParticipant} />
-          </aside>
-        </li>
-      </ul>
     </div>
   </div>
+</div>
+
+<!-- Date navigation -->
+<div class="flex justify-between items-center mb-4">
+  <button class="btn btn-sm variant-ghost-surface" on:click={previousWeek}>
+    <Fa icon={faArrowLeft} />
+    <span>{$_('button.week')}</span>
+  </button>
+  <h3 class="h3">{formattedDate}</h3>
+  <button class="btn btn-sm variant-ghost-surface" on:click={nextWeek}>
+    <span>{$_('button.week')}</span>
+    <Fa icon={faArrowRight} />
+  </button>
+</div>
+
+<!-- View toggle tabs -->
+<div class="flex gap-1 mb-4">
+  <button
+    class="btn btn-sm flex-1 {!showLessonPlan
+      ? 'variant-filled-primary'
+      : 'variant-soft-surface'}"
+    on:click={() => (showLessonPlan = false)}
+  >
+    <Fa icon={faUsers} />
+    <span>{$_('page.trainings.attendance')}</span>
+  </button>
+  <button
+    class="btn btn-sm flex-1 {showLessonPlan
+      ? 'variant-filled-primary'
+      : 'variant-soft-surface'}"
+    on:click={() => (showLessonPlan = true)}
+  >
+    <Fa icon={faClipboardList} />
+    <span>{$_('page.trainings.lessonPlan')}</span>
+  </button>
+</div>
+
+{#if !showLessonPlan}
+  <!-- Stats bar -->
+  <div class="flex gap-2 mb-3 flex-wrap">
+    <span class="chip variant-filled-primary">
+      <Fa icon={faUserCheck} size="sm" />
+      <span>{presentParticipants.length} / {filteredData.length}</span>
+    </span>
+    {#if mainTrainers.length > 0}
+      <span class="chip variant-filled-warning">
+        <img class="inline-block w-3.5" src="/judo-icon.svg" alt="trainer" />
+        <span>{mainTrainers.length}</span>
+      </span>
+    {/if}
+    {#if assistantTrainers.length > 0}
+      <span class="chip variant-filled-surface">
+        <Fa icon={faChalkboardTeacher} size="sm" />
+        <span>{assistantTrainers.length}</span>
+      </span>
+    {/if}
+  </div>
+
+  <!-- Trainer warning -->
+  {#if presentParticipants.length > 0 && !hasMainTrainer}
+    <aside class="alert variant-ghost-warning mb-3">
+      <div><Fa icon={faExclamationTriangle} class="text-warning-500" /></div>
+      <div class="alert-message">
+        <p>
+          <span class="font-bold">{$_('page.trainings.noMainTrainerWarning.title')}</span>
+          {$_('page.trainings.noMainTrainerWarning.message')}
+        </p>
+      </div>
+    </aside>
+  {/if}
+
+  <!-- Search -->
+  <div class="mb-3">
+    <input
+      class="input"
+      on:keydown={navigateList}
+      type="text"
+      placeholder={$_('page.trainings.searchMembersPlaceholder')}
+      bind:value={searchterm}
+      on:input={filterData}
+      on:focus={() => (animateList = false)}
+      on:blur={() => (animateList = true)}
+    />
+  </div>
+
+  <!-- Participant list -->
+  <ul class="list">
+    {#each filteredData as p, i (p.id)}
+      <div
+        class="item"
+        animate:flip={{ delay: 0, duration: animateList ? 400 : 0, easing: quintInOut }}
+      >
+        <ParticipantCard
+          highlight={hiIndex === i}
+          member={p}
+          on:change={changePresence}
+          on:remove={removeParticipant}
+        />
+      </div>
+    {/each}
+    <li>
+      <aside class="alert variant-ghost-tertiary w-full justify-items-center">
+        <AddParticipantInputBox on:add={addParticipant} />
+      </aside>
+    </li>
+  </ul>
 {:else}
   <LessonPlan trainingId={data.trainingId} date={data.date} />
 {/if}

--- a/src/routes/dashboard/trainings/[trainingId]/[date]/Labels.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/[date]/Labels.svelte
@@ -3,9 +3,10 @@
 </script>
 
 {#each labels as l, i (l)}
-  {#if i > 1}
-    .
-  {:else}
-    <span class="chip sm mr-1 p-1 variant-ghost-secondary">{l}</span>
+  {#if i < 2}
+    <span class="chip variant-ghost-secondary text-xs mr-1 px-1.5 py-0.5">{l}</span>
   {/if}
 {/each}
+{#if labels.length > 2}
+  <span class="chip variant-ghost-surface text-xs px-1.5 py-0.5">+{labels.length - 2}</span>
+{/if}

--- a/src/routes/dashboard/trainings/[trainingId]/[date]/ParticipantCard.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/[date]/ParticipantCard.svelte
@@ -24,9 +24,7 @@
       type: 'confirm',
       title: $_('dialog.confirm.title'),
       body: $_('dialog.confirm.body'),
-      // TRUE if confirm pressed, FALSE if cancel pressed
       response: (r: boolean) => r === true && dispatch('remove', { member }),
-      // Optionally override the button text
       buttonTextCancel: $_('button.cancel'),
       buttonTextConfirm: $_('button.confirm')
     };
@@ -38,7 +36,9 @@
   }
 </script>
 
-<li class={highlight ? 'bg-primary-50' : ''}>
+<li
+  class="rounded-lg transition-colors {highlight ? 'bg-primary-100 dark:bg-primary-900/30' : ''} {member.isPresent ? '' : 'opacity-50'}"
+>
   {#if member}
     <input
       class="checkbox"
@@ -47,42 +47,44 @@
       checked={member.isPresent}
       on:change={change}
     />
-    <div class="relative inline-block">
+    <div class="relative inline-block flex-shrink-0">
       {#if member.trainerRole === 'main_trainer'}
-        <span class="badge-icon absolute -bottom-0 -right-0 z-10 bg-yellow-500 rounded-full">
-          <img src="/judo-icon.svg" alt="main-trainer" />
+        <span
+          class="badge-icon absolute -bottom-0 -right-0 z-10 bg-warning-500 rounded-full w-5 h-5 flex items-center justify-center"
+        >
+          <img class="w-3.5" src="/judo-icon.svg" alt="main-trainer" />
         </span>
       {:else if member.trainerRole === 'assistant'}
         <span
-          class="badge-icon absolute -bottom-0 -right-0 z-10 bg-gray-400 text-white text-xs font-bold px-1.5 py-0.5 rounded-full"
+          class="badge-icon absolute -bottom-0 -right-0 z-10 bg-surface-400 text-white text-xs font-bold w-5 h-5 flex items-center justify-center rounded-full"
         >
           A
         </span>
       {/if}
       {#if member.img}
-        <Avatar src={member.img} />
+        <Avatar src={member.img} width="w-10" />
       {:else}
-        <Avatar initials={member.lastname.charAt(0) + member.firstname.charAt(0)} />
+        <Avatar initials={member.lastname.charAt(0) + member.firstname.charAt(0)} width="w-10" />
       {/if}
     </div>
-    <span class="flex-auto">
-      <dt>{member.lastname} {member.firstname}</dt>
+    <span class="flex-auto min-w-0">
+      <dt class="font-semibold truncate">{member.lastname} {member.firstname}</dt>
       <dd>
         <Labels labels={member.labels ? member.labels : []} />
       </dd>
     </span>
-    <div class="justify-self-end relative">
-      <button class="btn" use:menu={{ menu: 'ParticipantCard' + member.id }}>
+    <div class="justify-self-end relative flex-shrink-0">
+      <button class="btn btn-sm" use:menu={{ menu: 'ParticipantCard' + member.id }}>
         <Fa icon={faEllipsisVertical} />
       </button>
-      <nav class="card p-2 w-48 shadow-xl" data-menu={'ParticipantCard' + member.id}>
+      <nav class="card p-2 w-48 shadow-xl z-50" data-menu={'ParticipantCard' + member.id}>
         <ul>
           <li>
             <a href={'/dashboard/members/' + member.id} class="btn option w-full">
               {$_('components.ParticipantCard.View')}
             </a>
           </li>
-          <li class="border-t pt-2 mt-2">
+          <li class="border-t border-surface-300 pt-2 mt-2">
             <button class="option w-full" on:click={() => setTrainerRole('attendee')}>
               {$_('components.ParticipantCard.SetAsAttendee')}
             </button>
@@ -99,8 +101,8 @@
               <span class="pl-1">{$_('components.ParticipantCard.SetAsAssistant')}</span>
             </button>
           </li>
-          <li class="border-t pt-2 mt-2">
-            <button class="option w-full" on:click={triggerConfirm}>
+          <li class="border-t border-surface-300 pt-2 mt-2">
+            <button class="option w-full text-error-500" on:click={triggerConfirm}>
               {$_('components.ParticipantCard.Remove')}
             </button>
           </li>


### PR DESCRIPTION
## Summary
- **Header**: Training info in a clean card with section badge and metadata
- **Date navigation**: Human-readable date format (DD. MMMM YYYY), compact ghost-style buttons
- **View toggle**: Tab-style buttons for Attendance / Lesson Plan replacing single toggle
- **Stats bar**: Live chips showing present/total count, trainer and assistant counts
- **ParticipantCard**: Absent members dimmed with opacity, smaller avatars, truncation-safe layout, red-styled remove option
- **Labels**: Shows `+N` count instead of "." for overflow

## Test plan
- [ ] Verify header displays training title, section badge, weekday and time correctly
- [ ] Navigate between weeks and confirm the formatted date updates
- [ ] Toggle between Attendance and Lesson Plan tabs
- [ ] Check in/out participants and verify stats bar updates live
- [ ] Confirm absent members appear dimmed, present members are full opacity
- [ ] Verify trainer role badges (main trainer / assistant) display correctly
- [ ] Test the 3-dot menu actions (view, set role, remove)
- [ ] Test with members having 3+ labels to verify "+N" overflow display
- [ ] Verify keyboard navigation (arrow keys + enter) still works

https://claude.ai/code/session_01Vp4uTk3AcFNfoFPCARQEKv