### PR TITLE
Improve trainings detail page design with card-based layout

### DIFF
--- a/src/routes/dashboard/trainings/[trainingId]/+page.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/+page.svelte
@@ -4,50 +4,72 @@
   import LogList from './LogList.svelte';
   import utils from '$lib/utils';
   import { _ } from 'svelte-i18n';
+  import Fa from 'svelte-fa';
+  import {
+    faCalendarDays,
+    faCalendarCheck,
+    faUsers,
+    faClipboardCheck,
+    faLayerGroup
+  } from '@fortawesome/free-solid-svg-icons';
+  import dayjs from 'dayjs';
 
   function getDateString() {
     const weekday = utils.weekdayToNumber(data.weekday);
     return utils.getMostRecentDateByWeekday(weekday).format('YYYY-MM-DD');
   }
+
+  function formatDate(date: string) {
+    return dayjs(date).format('DD.MM.YYYY');
+  }
 </script>
 
-<h1>{$_('page.trainings.id')}: {data.id}</h1>
-<table>
-  <tr>
-    <td>{$_('page.trainings.trainingsTitle')}:</td>
-    <td>{data.title}</td>
-  </tr>
-  <tr>
-    <td>{$_('page.trainings.participants')} #:</td>
-    <td>{data.participants.length}</td>
-  </tr>
-  <tr>
-    <td>{$_('page.trainings.weekday')}:</td>
-    <td>{$_('weekday.' + data.weekday)}</td>
-  </tr>
-  <tr>
-    <td>{$_('page.trainings.dateFrom')}:</td>
-    <td>{data.dateFrom}</td>
-  </tr>
-  <tr>
-    <td>{$_('page.trainings.dateTo')}:</td>
-    <td>{data.dateTo}</td>
-  </tr>
-  <tr>
-    <td>{$_('page.trainings.section')}:</td>
-    <td>{data.section}</td>
-  </tr>
-</table>
-
-<div class="w-full grid grid-cols-2">
-  <h2>{$_('page.trainings.logs')}</h2>
-  <div class="text-right">
+<!-- Header -->
+<div class="card p-4 mb-6">
+  <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+    <div>
+      <h2 class="h2">{data.title}</h2>
+      <div class="flex items-center gap-2 mt-1">
+        <span class="badge variant-filled-secondary">{data.section}</span>
+        <span class="text-sm opacity-70">{$_('weekday.' + data.weekday)}</span>
+      </div>
+    </div>
     <a
-      class="btn btn-sm variant-filled-primary"
+      class="btn variant-filled-primary"
       href="/dashboard/trainings/{data.id}/{getDateString()}"
     >
-      {$_('button.trackAttendance')}
+      <Fa icon={faClipboardCheck} />
+      <span>{$_('button.trackAttendance')}</span>
     </a>
   </div>
+</div>
+
+<!-- Info cards -->
+<div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
+  <div class="card p-3 text-center">
+    <Fa icon={faUsers} class="text-primary-500 mb-1" size="lg" />
+    <p class="text-2xl font-bold">{data.participants.length}</p>
+    <p class="text-xs opacity-70">{$_('page.trainings.participants')}</p>
+  </div>
+  <div class="card p-3 text-center">
+    <Fa icon={faLayerGroup} class="text-secondary-500 mb-1" size="lg" />
+    <p class="text-sm font-bold mt-1">{data.section}</p>
+    <p class="text-xs opacity-70">{$_('page.trainings.section')}</p>
+  </div>
+  <div class="card p-3 text-center">
+    <Fa icon={faCalendarDays} class="text-tertiary-500 mb-1" size="lg" />
+    <p class="text-sm font-bold mt-1">{formatDate(data.dateFrom)}</p>
+    <p class="text-xs opacity-70">{$_('page.trainings.dateFrom')}</p>
+  </div>
+  <div class="card p-3 text-center">
+    <Fa icon={faCalendarCheck} class="text-tertiary-500 mb-1" size="lg" />
+    <p class="text-sm font-bold mt-1">{formatDate(data.dateTo)}</p>
+    <p class="text-xs opacity-70">{$_('page.trainings.dateTo')}</p>
+  </div>
+</div>
+
+<!-- Logs section -->
+<div class="flex items-center justify-between mb-3">
+  <h3 class="h3">{$_('page.trainings.logs')}</h3>
 </div>
 <LogList trainingId={data.id} />

--- a/src/routes/dashboard/trainings/[trainingId]/LogList.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/LogList.svelte
@@ -1,9 +1,15 @@
 <script lang="ts">
   import { error as err } from '@sveltejs/kit';
   import Fa from 'svelte-fa';
-  import { faGripLines, faExclamationTriangle } from '@fortawesome/free-solid-svg-icons';
+  import {
+    faGripLines,
+    faExclamationTriangle,
+    faCalendarDays,
+    faCheckCircle
+  } from '@fortawesome/free-solid-svg-icons';
   import { supabaseClient } from '$lib/supabase';
   import { _ } from 'svelte-i18n';
+  import dayjs from 'dayjs';
 
   export let trainingId: string;
 
@@ -13,6 +19,14 @@
     count: number;
     totalTrainerCount: number;
     hasLessonPlan: boolean;
+  }
+
+  function formatDate(date: string) {
+    return dayjs(date).format('DD.MM.YYYY');
+  }
+
+  function formatWeekday(date: string) {
+    return dayjs(date).format('ddd');
   }
 
   async function getLogs() {
@@ -31,45 +45,64 @@
 </script>
 
 {#await getLogs() then logs}
-  <ul class="list">
-    {#each logs as i (i.date)}
-      <li>
-        <span>
-          {i.date}
-        </span>
-        <span class="flex-auto">
-          <div class="flex items-center gap-2">
-            <span class="chip variant-filled-secondary">{i.count}</span>
-            <span class="text-sm opacity-75">{$_('page.trainings.participants')}</span>
+  {#if logs.length === 0}
+    <div class="card p-6 text-center">
+      <p class="opacity-50">{$_('page.trainings.noLessonPlanMessage')}</p>
+    </div>
+  {:else}
+    <div class="space-y-2">
+      {#each logs as i (i.date)}
+        <a
+          href="/dashboard/trainings/{trainingId}/{i.date}"
+          class="card p-3 flex items-center gap-3 hover:variant-soft-primary transition-colors"
+        >
+          <!-- Date -->
+          <div class="text-center flex-none w-16">
+            <p class="text-xs opacity-50 uppercase">{formatWeekday(i.date)}</p>
+            <p class="font-bold text-sm">{formatDate(i.date)}</p>
+          </div>
+
+          <!-- Divider -->
+          <div class="border-l border-surface-400/30 h-8 flex-none"></div>
+
+          <!-- Stats -->
+          <div class="flex items-center gap-2 flex-auto flex-wrap">
+            <span class="chip variant-filled-secondary">
+              {i.count}
+              <span class="ml-1 text-xs">{$_('page.trainings.participants')}</span>
+            </span>
+
             {#if i.totalTrainerCount > 0}
               <span class="chip variant-filled-success">
                 <img class="inline-block w-3" src="/judo-icon.svg" alt="trainer" />
-                {i.totalTrainerCount}
+                <span class="ml-1">{i.totalTrainerCount}</span>
               </span>
             {:else}
               <span class="chip variant-filled-warning">
                 <Fa icon={faExclamationTriangle} class="w-3" />
-                <span class="text-xs">{$_('page.trainings.noTrainer')}</span>
+                <span class="ml-1 text-xs">{$_('page.trainings.noTrainer')}</span>
               </span>
             {/if}
-            {#if !i.hasLessonPlan}
+
+            {#if i.hasLessonPlan}
+              <span class="chip variant-soft-success">
+                <Fa icon={faCheckCircle} size="xs" />
+                <span class="ml-1 text-xs">{$_('page.trainings.hasLessonPlan')}</span>
+              </span>
+            {:else}
               <span class="chip variant-filled-warning">
                 <Fa icon={faExclamationTriangle} class="w-3" />
-                <span class="text-xs">{$_('page.trainings.noLessonPlan')}</span>
+                <span class="ml-1 text-xs">{$_('page.trainings.noLessonPlan')}</span>
               </span>
             {/if}
           </div>
-        </span>
-        <span>
-          <a
-            class="btn btn-sm variant-filled-secondary"
-            href="/dashboard/trainings/{trainingId}/{i.date}"
-          >
+
+          <!-- Arrow -->
+          <div class="flex-none opacity-50">
             <Fa icon={faGripLines} />
-            <span>{$_('button.view')}</span>
-          </a>
-        </span>
-      </li>
-    {/each}
-  </ul>
+          </div>
+        </a>
+      {/each}
+    </div>
+  {/if}
 {/await}


### PR DESCRIPTION
Redesign the training overview page with a proper header card showing
title/section/weekday, stat cards for participants/dates, and a
card-based log list with formatted dates and visual status indicators.

https://claude.ai/code/session_01U8r3UNP2b2fzdo7RoDvbRm