### PR TITLE
Improve trainings detail page design

### DIFF
--- a/src/routes/dashboard/trainings/[trainingId]/+page.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/+page.svelte
@@ -6,21 +6,14 @@
   import { _ } from 'svelte-i18n';
   import Fa from 'svelte-fa';
   import {
-    faCalendarDays,
-    faCalendarCheck,
+    faClock,
     faUsers,
-    faClipboardCheck,
-    faLayerGroup
+    faClipboardCheck
   } from '@fortawesome/free-solid-svg-icons';
-  import dayjs from 'dayjs';
 
   function getDateString() {
     const weekday = utils.weekdayToNumber(data.weekday);
     return utils.getMostRecentDateByWeekday(weekday).format('YYYY-MM-DD');
-  }
-
-  function formatDate(date: string) {
-    return dayjs(date).format('DD.MM.YYYY');
   }
 </script>
 
@@ -29,42 +22,26 @@
   <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
     <div>
       <h2 class="h2">{data.title}</h2>
-      <div class="flex items-center gap-2 mt-1">
+      <div class="flex items-center gap-2 mt-2 flex-wrap">
         <span class="badge variant-filled-secondary">{data.section}</span>
-        <span class="text-sm opacity-70">{$_('weekday.' + data.weekday)}</span>
+        <span class="badge variant-soft-surface">{$_('weekday.' + data.weekday)}</span>
+        <span class="badge variant-soft-surface">
+          <Fa icon={faClock} size="xs" class="mr-1" />
+          {data.dateFrom} – {data.dateTo}
+        </span>
+        <span class="badge variant-soft-surface">
+          <Fa icon={faUsers} size="xs" class="mr-1" />
+          {data.participants.length} {$_('page.trainings.participants')}
+        </span>
       </div>
     </div>
     <a
-      class="btn variant-filled-primary"
+      class="btn variant-filled-primary flex-none"
       href="/dashboard/trainings/{data.id}/{getDateString()}"
     >
       <Fa icon={faClipboardCheck} />
       <span>{$_('button.trackAttendance')}</span>
     </a>
-  </div>
-</div>
-
-<!-- Info cards -->
-<div class="grid grid-cols-2 sm:grid-cols-4 gap-3 mb-6">
-  <div class="card p-3 text-center">
-    <Fa icon={faUsers} class="text-primary-500 mb-1" size="lg" />
-    <p class="text-2xl font-bold">{data.participants.length}</p>
-    <p class="text-xs opacity-70">{$_('page.trainings.participants')}</p>
-  </div>
-  <div class="card p-3 text-center">
-    <Fa icon={faLayerGroup} class="text-secondary-500 mb-1" size="lg" />
-    <p class="text-sm font-bold mt-1">{data.section}</p>
-    <p class="text-xs opacity-70">{$_('page.trainings.section')}</p>
-  </div>
-  <div class="card p-3 text-center">
-    <Fa icon={faCalendarDays} class="text-tertiary-500 mb-1" size="lg" />
-    <p class="text-sm font-bold mt-1">{formatDate(data.dateFrom)}</p>
-    <p class="text-xs opacity-70">{$_('page.trainings.dateFrom')}</p>
-  </div>
-  <div class="card p-3 text-center">
-    <Fa icon={faCalendarCheck} class="text-tertiary-500 mb-1" size="lg" />
-    <p class="text-sm font-bold mt-1">{formatDate(data.dateTo)}</p>
-    <p class="text-xs opacity-70">{$_('page.trainings.dateTo')}</p>
   </div>
 </div>
 


### PR DESCRIPTION
## Summary
- Redesigned training detail page with a card-based header showing title, section badge, weekday, time range, and participant count
- Improved log list with clickable card entries, formatted dates, visual dividers, and status indicators (trainer count, lesson plan)
- Replaced plain HTML table layout with modern Skeleton UI components consistent with the rest of the app

https://claude.ai/code/session_01U8r3UNP2b2fzdo7RoDvbRm