### PR TITLE
Fix lesson plan upload: save button disabled and missing error feedback

### DIFF
--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -67,7 +67,9 @@
       "or": "oder",
       "writeContent": "Inhalt Schreiben",
       "textDisabledWhenFileSelected": "Textinhalt ist deaktiviert wenn eine Datei ausgewählt ist",
-      "uploading": "Hochladen..."
+      "uploading": "Hochladen...",
+      "uploadError": "Fehler beim Hochladen der Datei",
+      "saveError": "Fehler beim Speichern des Lektionsplans"
     },
     "members": {
       "title": "Mitglieder",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -67,7 +67,9 @@
       "or": "or",
       "writeContent": "Write Content",
       "textDisabledWhenFileSelected": "Text content is disabled when a file is selected",
-      "uploading": "Uploading..."
+      "uploading": "Uploading...",
+      "uploadError": "Error uploading file",
+      "saveError": "Error saving lesson plan"
     },
     "members": {
       "title": "Members",

--- a/src/routes/dashboard/trainings/[trainingId]/[date]/LessonPlan.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/[date]/LessonPlan.svelte
@@ -2,7 +2,7 @@
   import { supabaseClient } from '$lib/supabase';
   import type { LessonPlan } from '$lib/models';
   import Fa from 'svelte-fa';
-  import { TabGroup, Tab } from '@skeletonlabs/skeleton';
+  import { TabGroup, Tab, toastStore } from '@skeletonlabs/skeleton';
   import {
     faEdit,
     faSave,
@@ -83,7 +83,7 @@
   }
 
   async function saveLessonPlan() {
-    if (tabSet === 1 && !selectedFile) return;
+    if (tabSet === 1 && !selectedFile && !lessonPlan?.filePath) return;
     if (tabSet === 0 && !content.trim()) return;
 
     isLoading = true;
@@ -113,6 +113,10 @@
 
         if (uploadError) {
           console.error('Error uploading file:', uploadError);
+          toastStore.trigger({
+            message: $_('page.trainings.uploadError'),
+            preset: 'error'
+          });
           return;
         }
       }
@@ -143,12 +147,14 @@
         };
 
         if (tabSet === 1 && selectedFile) {
-          // File upload - clear content, set file fields
+          // New file upload - clear content, set file fields
           updateData.content = null;
           updateData.file_name = fileName;
           updateData.file_path = filePath;
           updateData.file_type = fileType;
           updateData.file_size = fileSize;
+        } else if (tabSet === 1 && !selectedFile) {
+          // Keep existing file - only update title
         } else {
           // Text content - clear file fields, set content
           updateData.content = content.trim();
@@ -167,6 +173,10 @@
 
         if (error) {
           console.error('Error updating lesson plan:', error);
+          toastStore.trigger({
+            message: $_('page.trainings.saveError'),
+            preset: 'error'
+          });
           return;
         }
 
@@ -231,6 +241,10 @@
 
         if (error) {
           console.error('Error creating lesson plan:', error);
+          toastStore.trigger({
+            message: $_('page.trainings.saveError'),
+            preset: 'error'
+          });
           return;
         }
 
@@ -382,7 +396,7 @@
           on:click={saveLessonPlan}
           disabled={isLoading ||
             (tabSet === 0 && !content.trim()) ||
-            (tabSet === 1 && !selectedFile)}
+            (tabSet === 1 && !selectedFile && !lessonPlan?.filePath)}
         >
           <Fa icon={faSave} />
           <span>{$_('button.save')}</span>


### PR DESCRIPTION
The save button was always disabled when editing an existing file-based
lesson plan because it required a new file selection even when a file
already existed. Also, the update logic would incorrectly clear file
fields when no new file was selected, violating the database constraint.

Added user-visible toast error messages for upload and save failures
(previously errors were only logged to console).

https://claude.ai/code/session_01WBNmAh3eXJSvZ9jqSHZZr6