### PR TITLE
Fix attendance date not displayed according to locale

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -3,7 +3,13 @@
   import { invalidateAll } from '$app/navigation';
   import { supabaseClient } from '$lib/supabase';
   import { onMount } from 'svelte';
+  import dayjs from 'dayjs';
   import 'dayjs/locale/de';
+  import { locale } from 'svelte-i18n';
+
+  $: if ($locale) {
+    dayjs.locale($locale.startsWith('de') ? 'de' : 'en');
+  }
   import '../theme.postcss';
   import '@skeletonlabs/skeleton/styles/all.css';
   import '../app.postcss';


### PR DESCRIPTION
Set dayjs global locale reactively based on svelte-i18n's locale store,
so date formatting (month names, weekday abbreviations) respects the
user's language throughout the app.

https://claude.ai/code/session_0155BnYu67gqwFUAfXHZ9pLR