### PR TITLE
Include current session as reactive dot in participation streak

### DIFF
--- a/src/routes/dashboard/trainings/[trainingId]/[date]/+page.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/[date]/+page.svelte
@@ -109,7 +109,8 @@
       .single();
 
     if (d.data?.members) {
-      data.participants.push(d.data.members as unknown as MMember);
+      const newMember = { ...(d.data.members as unknown as MMember), streak: [] };
+      data.participants.push(newMember);
     }
     _changePresence(event.detail.member, true, 'attendee');
     filterData();

--- a/src/routes/dashboard/trainings/[trainingId]/[date]/+page.ts
+++ b/src/routes/dashboard/trainings/[trainingId]/[date]/+page.ts
@@ -20,7 +20,7 @@ interface StreakRow {
   seq: number;
 }
 
-const STREAK_LENGTH = 10;
+const STREAK_LENGTH = 9;
 
 export const load = (async ({ params }) => {
   async function getMembersWithPresentStatus(): Promise<MMember[]> {

--- a/src/routes/dashboard/trainings/[trainingId]/[date]/ParticipantCard.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/[date]/ParticipantCard.svelte
@@ -106,7 +106,7 @@
         <Labels labels={member.labels ? member.labels : []} />
       </dd>
       <dd>
-        <ParticipantFrequency streak={member.streak} />
+        <ParticipantFrequency streak={member.streak} isPresent={member.isPresent} />
       </dd>
     </span>
     <div class="justify-self-end flex-shrink-0">

--- a/src/routes/dashboard/trainings/[trainingId]/[date]/ParticipantFrequency.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/[date]/ParticipantFrequency.svelte
@@ -30,12 +30,12 @@
       <span
         class="inline-block rounded-full {isCurrent ? 'w-2 h-2' : 'w-1.5 h-1.5'}
           {attended
-            ? isCurrent
-              ? 'bg-primary-500 ring-1 ring-primary-300 dark:ring-primary-700'
-              : 'bg-primary-500'
-            : isCurrent
-              ? 'bg-surface-300 dark:bg-surface-600 ring-1 ring-surface-400 dark:ring-surface-500'
-              : 'bg-surface-300 dark:bg-surface-600'}"
+          ? isCurrent
+            ? 'bg-primary-500 ring-1 ring-primary-300 dark:ring-primary-700'
+            : 'bg-primary-500'
+          : isCurrent
+          ? 'bg-surface-300 dark:bg-surface-600 ring-1 ring-surface-400 dark:ring-surface-500'
+          : 'bg-surface-300 dark:bg-surface-600'}"
       />
     {/each}
     <span

--- a/src/routes/dashboard/trainings/[trainingId]/[date]/ParticipantFrequency.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/[date]/ParticipantFrequency.svelte
@@ -1,31 +1,41 @@
 <script lang="ts">
   import { _ } from 'svelte-i18n';
 
+  /** Historical attendance for last N sessions (oldest first). */
   export let streak: boolean[];
+  /** Whether the participant is checked as present for the current session. */
+  export let isPresent: boolean;
 
-  const RECENT_HALF = Math.ceil(streak.length / 2);
+  $: fullStreak = [...streak, isPresent];
 
-  $: recentCount = streak.slice(-RECENT_HALF).filter(Boolean).length;
-  $: olderCount = streak.slice(0, RECENT_HALF).filter(Boolean).length;
+  $: recentHalf = Math.ceil(fullStreak.length / 2);
+  $: recentCount = fullStreak.slice(-recentHalf).filter(Boolean).length;
+  $: olderCount = fullStreak.slice(0, recentHalf).filter(Boolean).length;
   $: trend = recentCount > olderCount ? 'up' : recentCount < olderCount ? 'down' : 'stable';
 
-  $: totalAttended = streak.filter(Boolean).length;
+  $: totalAttended = fullStreak.filter(Boolean).length;
   $: tooltipText =
     totalAttended +
     '/' +
-    streak.length +
+    fullStreak.length +
     ' ' +
     $_('components.ParticipantFrequency.sessions') +
     (trend === 'up' ? ' \u2197' : trend === 'down' ? ' \u2198' : '');
 </script>
 
-{#if streak.length > 0}
+{#if fullStreak.length > 0}
   <div class="flex items-center gap-0.5" title={tooltipText} aria-label={tooltipText}>
-    {#each streak as attended}
+    {#each fullStreak as attended, i}
+      {@const isCurrent = i === fullStreak.length - 1}
       <span
-        class="inline-block w-1.5 h-1.5 rounded-full {attended
-          ? 'bg-primary-500'
-          : 'bg-surface-300 dark:bg-surface-600'}"
+        class="inline-block rounded-full {isCurrent ? 'w-2 h-2' : 'w-1.5 h-1.5'}
+          {attended
+            ? isCurrent
+              ? 'bg-primary-500 ring-1 ring-primary-300 dark:ring-primary-700'
+              : 'bg-primary-500'
+            : isCurrent
+              ? 'bg-surface-300 dark:bg-surface-600 ring-1 ring-surface-400 dark:ring-surface-500'
+              : 'bg-surface-300 dark:bg-surface-600'}"
       />
     {/each}
     <span


### PR DESCRIPTION
## Summary

- The **last dot** in the participation streak now represents **today's session** and reactively toggles filled/empty when the trainer checks/unchecks a participant
- Today's dot is visually distinguished: slightly larger with a ring outline
- Historical streak reduced from 10 to 9 so total remains 10 dots
- Trend arrow also updates in real time based on the current check state
- New participants added via search get an empty streak with just the current-day dot

### Visual example
```
● ● ○ ● ● ● ○ ● ○ ◉  ↗
 ── historical (9) ──  today
```

### Files changed
| File | Change |
|------|--------|
| `ParticipantFrequency.svelte` | Accepts `isPresent` prop, appends reactive current-day dot with ring styling |
| `ParticipantCard.svelte` | Passes `isPresent={member.isPresent}` to frequency component |
| `+page.ts` | Streak length reduced to 9 (historical) |
| `+page.svelte` | New participants get `streak: []` default |

## Test plan

- [ ] Open attendance checklist — verify 10 dots appear (9 historical + 1 current)
- [ ] Check a participant — verify the last dot fills immediately
- [ ] Uncheck a participant — verify the last dot empties immediately
- [ ] Verify the trend arrow updates when toggling presence (e.g. ↘ becomes · or ↗)
- [ ] Add a new participant — verify only the current-day dot appears (no historical data)
- [ ] Hover over dots — verify tooltip shows correct "X/10 sessions attended"

https://claude.ai/code/session_01Jagt73ghwnp9GqfyLHJ8Cf