### PR TITLE
Improve lesson plan upload reliability and error feedback

### DIFF
--- a/src/routes/dashboard/trainings/[trainingId]/[date]/LessonPlan.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/[date]/LessonPlan.svelte
@@ -108,13 +108,14 @@
           .from('lesson-plans')
           .upload(filePath, selectedFile, {
             cacheControl: '3600',
-            upsert: false
+            contentType: selectedFile.type,
+            upsert: true
           });
 
         if (uploadError) {
           console.error('Error uploading file:', uploadError);
           toastStore.trigger({
-            message: $_('page.trainings.uploadError'),
+            message: `${$_('page.trainings.uploadError')}: ${uploadError.message}`,
             preset: 'error'
           });
           return;
@@ -174,7 +175,7 @@
         if (error) {
           console.error('Error updating lesson plan:', error);
           toastStore.trigger({
-            message: $_('page.trainings.saveError'),
+            message: `${$_('page.trainings.saveError')}: ${error.message}`,
             preset: 'error'
           });
           return;
@@ -242,7 +243,7 @@
         if (error) {
           console.error('Error creating lesson plan:', error);
           toastStore.trigger({
-            message: $_('page.trainings.saveError'),
+            message: `${$_('page.trainings.saveError')}: ${error.message}`,
             preset: 'error'
           });
           return;


### PR DESCRIPTION
## Summary
- Add explicit `contentType` to storage upload for correct MIME type handling
- Use `upsert: true` to avoid conflicts on duplicate storage paths
- Include the actual Supabase error message in toast notifications so users can see what went wrong

## Context
The lesson plan file upload was failing with no useful feedback. Root causes were:
1. **Storage bucket missing** in production — fixed manually via Supabase Dashboard
2. **File columns missing** from `lesson_plans` table — fixed via SQL Editor (original migration was modified after it had already been applied)
3. **Generic error toasts** — this PR adds the actual error details to the toast message

## Test plan
- [ ] Upload a file (PDF, image) as a lesson plan — should succeed
- [ ] Verify error toast shows specific message if upload fails (e.g. disconnect network and try)

https://claude.ai/code/session_01WBNmAh3eXJSvZ9jqSHZZr6