### PR TITLE
Improve mobile UI consistency across all pages

### DIFF
--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -213,7 +213,9 @@
     "deleting": "Lösche...",
     "create": "Erstellen",
     "creating": "Erstelle...",
-    "download": "Herunterladen"
+    "download": "Herunterladen",
+    "lightMode": "Heller Modus",
+    "darkMode": "Dunkler Modus"
   },
   "dialog": {
     "newMember": {

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -213,7 +213,9 @@
     "deleting": "Deleting...",
     "create": "Create",
     "creating": "Creating...",
-    "download": "Download"
+    "download": "Download",
+    "lightMode": "Light Mode",
+    "darkMode": "Dark Mode"
   },
   "dialog": {
     "newMember": {

--- a/src/routes/dashboard/+layout.svelte
+++ b/src/routes/dashboard/+layout.svelte
@@ -172,7 +172,7 @@
             onclick={toggleDarkMode}
           >
             <Fa icon={isDark ? faSun : faMoon} />
-            <span>{isDark ? 'Light Mode' : 'Dark Mode'}</span>
+            <span>{isDark ? $_('button.lightMode') : $_('button.darkMode')}</span>
           </button>
           <form action="/logout" method="POST" use:enhance={submitLogout}>
             <button type="submit" class="btn preset-filled w-full">

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -61,7 +61,7 @@
   getTodayEvents();
 </script>
 
-<div class="flex justify-between items-center m-2">
+<div class="flex justify-between items-center mb-4">
   <div>
     <button class="btn" onclick={previousDay}>
       <Fa icon={faArrowLeft} /><span>{$_('button.day')}</span>
@@ -80,7 +80,7 @@
 <!-- Trainings Section -->
 <section class="mb-6">
   {#if trainings.length == 0}
-    <div class="text-center text-surface-600-400">{$_('page.dashboard.noTrainingsToday')}</div>
+    <div class="text-center text-surface-600-400 py-8">{$_('page.dashboard.noTrainingsToday')}</div>
   {:else}
     <ul class="flex flex-col gap-3">
       {#each trainings as t (t.id)}

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -94,7 +94,7 @@
               href="/dashboard/trainings/{t.id}/{date.format(dateFormat)}"
             >
               <Fa icon={faClipboardCheck} />
-              <span>{$_('button.trackAttendance')}</span>
+              <span class="hidden sm:inline">{$_('button.trackAttendance')}</span>
             </a>
           </span>
         </li>
@@ -143,7 +143,7 @@
           <span class="flex-none">
             <a class="btn btn-sm preset-tonal-primary" href="/dashboard/events/{event.id}">
               <Fa icon={faClipboardCheck} />
-              <span>{$_('button.trackAttendance')}</span>
+              <span class="hidden sm:inline">{$_('button.trackAttendance')}</span>
             </a>
           </span>
         </li>

--- a/src/routes/dashboard/events/+page.svelte
+++ b/src/routes/dashboard/events/+page.svelte
@@ -123,7 +123,7 @@
               <span class="flex-none">
                 <a class="btn btn-sm preset-tonal-primary" href="/dashboard/events/{event.id}">
                   <Fa icon={faGripLines} />
-                  <span>{$_('button.view')}</span>
+                  <span class="hidden sm:inline">{$_('button.view')}</span>
                 </a>
               </span>
             </li>
@@ -177,7 +177,7 @@
               <span class="flex-none">
                 <a class="btn btn-sm preset-tonal-primary" href="/dashboard/events/{event.id}">
                   <Fa icon={faGripLines} />
-                  <span>{$_('button.view')}</span>
+                  <span class="hidden sm:inline">{$_('button.view')}</span>
                 </a>
               </span>
             </li>
@@ -229,7 +229,7 @@
               <span class="flex-none">
                 <a class="btn btn-sm preset-tonal-primary" href="/dashboard/events/{event.id}">
                   <Fa icon={faGripLines} />
-                  <span>{$_('button.view')}</span>
+                  <span class="hidden sm:inline">{$_('button.view')}</span>
                 </a>
               </span>
             </li>

--- a/src/routes/dashboard/events/+page.svelte
+++ b/src/routes/dashboard/events/+page.svelte
@@ -52,7 +52,7 @@
   );
 </script>
 
-<div class="flex justify-between items-center mb-6">
+<div class="flex justify-between items-center mb-4">
   <h1>{$_('page.events.title')}</h1>
   <a href="/dashboard/events/new" class="btn btn-sm preset-filled-primary-500">
     <Fa icon={faPlus} />
@@ -61,7 +61,7 @@
 </div>
 
 <!-- Search Input -->
-<div class="mb-6">
+<div class="mb-4">
   <input
     class="input"
     bind:value={searchTerm}
@@ -84,7 +84,7 @@
     {#if filteredEvents.some((e) => isToday(e.date))}
       <section>
         <h3 class="text-lg font-semibold mb-3">{$_('page.events.today')}</h3>
-        <ul class="flex flex-col gap-1">
+        <ul class="flex flex-col gap-2">
           {#each filteredEvents.filter((e) => isToday(e.date)) as event (event.id)}
             <li class="flex items-center gap-3 py-2">
               <div class="relative inline-block flex-none">
@@ -138,7 +138,7 @@
         <h3 class="text-lg font-semibold mb-3">
           {$_('page.events.upcoming')}
         </h3>
-        <ul class="flex flex-col gap-1">
+        <ul class="flex flex-col gap-2">
           {#each filteredEvents.filter((e) => isUpcoming(e.date)) as event (event.id)}
             <li class="flex items-center gap-3 py-2">
               <div class="relative inline-block flex-none">
@@ -190,7 +190,7 @@
     {#if filteredEvents.some((e) => isPast(e.date))}
       <section>
         <h3 class="text-lg font-semibold mb-3">{$_('page.events.past')}</h3>
-        <ul class="flex flex-col gap-1">
+        <ul class="flex flex-col gap-2">
           {#each filteredEvents.filter((e) => isPast(e.date)) as event (event.id)}
             <li class="flex items-center gap-3 py-2">
               <div class="relative inline-block flex-none">

--- a/src/routes/dashboard/events/[eventId]/+page.svelte
+++ b/src/routes/dashboard/events/[eventId]/+page.svelte
@@ -205,11 +205,14 @@
 
 <div class="max-w-4xl mx-auto">
   <!-- Header: back + title + actions -->
-  <div class="flex items-center gap-2 mb-2">
-    <a href="/dashboard/events" class="btn btn-sm preset-tonal-surface flex-shrink-0">
+  <div class="flex items-center gap-2 mb-4">
+    <a
+      href="/dashboard/events"
+      class="btn btn-sm preset-tonal-surface flex-shrink-0 min-w-[44px] min-h-[44px]"
+    >
       <Fa icon={faArrowLeft} />
     </a>
-    <h1 class="flex-1 truncate">{data.event.title}</h1>
+    <h1 class="flex-1 min-w-0 truncate">{data.event.title}</h1>
     <div class="flex gap-2 flex-shrink-0">
       <a href="/dashboard/events/{data.event.id}/edit" class="btn btn-sm preset-tonal-surface">
         <Fa icon={faEdit} />
@@ -284,17 +287,17 @@
   {/if}
 
   <!-- Event Statistics -->
-  <div class="grid grid-cols-3 gap-2 mb-4">
-    <div class="card p-3 text-center">
-      <div class="text-xl font-bold text-primary-600-400">{registeredCount}</div>
+  <div class="grid grid-cols-3 gap-2 sm:gap-4 mb-4">
+    <div class="card p-3 sm:p-4 text-center">
+      <div class="text-lg sm:text-xl font-bold text-primary-600-400">{registeredCount}</div>
       <div class="text-xs text-surface-600-400">{$_('page.events.stats.registered')}</div>
     </div>
-    <div class="card p-3 text-center">
-      <div class="text-xl font-bold text-success-600-400">{attendedCount}</div>
+    <div class="card p-3 sm:p-4 text-center">
+      <div class="text-lg sm:text-xl font-bold text-success-600-400">{attendedCount}</div>
       <div class="text-xs text-surface-600-400">{$_('page.events.stats.attended')}</div>
     </div>
-    <div class="card p-3 text-center">
-      <div class="text-xl font-bold text-tertiary-600-400">{attendanceRate}%</div>
+    <div class="card p-3 sm:p-4 text-center">
+      <div class="text-lg sm:text-xl font-bold text-tertiary-600-400">{attendanceRate}%</div>
       <div class="text-xs text-surface-600-400">{$_('page.events.stats.attendance_rate')}</div>
     </div>
   </div>

--- a/src/routes/dashboard/events/[eventId]/+page.svelte
+++ b/src/routes/dashboard/events/[eventId]/+page.svelte
@@ -386,7 +386,7 @@
                     <div
                       class="size-10 rounded-full bg-surface-100-900 flex items-center justify-center text-sm font-bold"
                     >
-                      {member.firstname[0]}{member.lastname[0]}
+                      {member.lastname[0]}{member.firstname[0]}
                     </div>
                   {/if}
                   {#if log && log.isCoach}

--- a/src/routes/dashboard/events/[eventId]/edit/+page.svelte
+++ b/src/routes/dashboard/events/[eventId]/edit/+page.svelte
@@ -65,7 +65,10 @@
 
 <div class="max-w-2xl mx-auto">
   <div class="flex items-center gap-2 mb-4">
-    <a href="/dashboard/events/{data.event.id}" class="btn btn-sm preset-tonal-surface">
+    <a
+      href="/dashboard/events/{data.event.id}"
+      class="btn btn-sm preset-tonal-surface min-w-[44px] min-h-[44px]"
+    >
       <Fa icon={faArrowLeft} />
     </a>
     <h1>{$_('page.events.edit_event')}</h1>

--- a/src/routes/dashboard/events/new/+page.svelte
+++ b/src/routes/dashboard/events/new/+page.svelte
@@ -61,7 +61,7 @@
 
 <div class="max-w-2xl mx-auto">
   <div class="flex items-center gap-2 mb-4">
-    <a href="/dashboard/events" class="btn btn-sm preset-tonal-surface">
+    <a href="/dashboard/events" class="btn btn-sm preset-tonal-surface min-w-[44px] min-h-[44px]">
       <Fa icon={faArrowLeft} />
     </a>
     <h1>{$_('page.events.create_event')}</h1>

--- a/src/routes/dashboard/members/+page.svelte
+++ b/src/routes/dashboard/members/+page.svelte
@@ -135,7 +135,7 @@
           href={'/dashboard/members/' + m.id}
         >
           <Fa icon={faGripLines} />
-          <span>{$_('button.view')}</span>
+          <span class="hidden sm:inline">{$_('button.view')}</span>
         </a>
       </li>
     {/if}

--- a/src/routes/dashboard/members/+page.svelte
+++ b/src/routes/dashboard/members/+page.svelte
@@ -111,7 +111,7 @@
   />
 </div>
 
-<ul class="flex flex-col gap-1">
+<ul class="flex flex-col gap-2">
   {#each data.members as m (m.id)}
     {#if search(m.firstname, m.lastname)}
       <li class="flex items-center gap-3 py-2">

--- a/src/routes/dashboard/members/[memberId]/+page.svelte
+++ b/src/routes/dashboard/members/[memberId]/+page.svelte
@@ -285,7 +285,7 @@
     </div>
   {/if}
 
-  <div class="card p-6">
+  <div class="card p-4">
     <!-- Avatar + Photo buttons -->
     <div class="flex flex-col items-center mb-6">
       <div class="relative">
@@ -325,16 +325,24 @@
           capture="user"
         />
         <button
-          class="btn btn-icon btn-sm preset-tonal-surface"
+          class="btn btn-icon preset-tonal-surface min-w-[44px] min-h-[44px]"
           onclick={selectFiles}
           title="Upload"
         >
           <Fa icon={faUpload} />
         </button>
-        <button class="btn btn-icon btn-sm preset-tonal-surface" onclick={takePhoto} title="Photo">
+        <button
+          class="btn btn-icon preset-tonal-surface min-w-[44px] min-h-[44px]"
+          onclick={takePhoto}
+          title="Photo"
+        >
           <Fa icon={faCamera} />
         </button>
-        <button class="btn btn-icon btn-sm preset-tonal-error" onclick={resetImage} title="Remove">
+        <button
+          class="btn btn-icon preset-tonal-error min-w-[44px] min-h-[44px]"
+          onclick={resetImage}
+          title="Remove"
+        >
           <Fa icon={faTrash} />
         </button>
       </div>

--- a/src/routes/dashboard/stats/[[year]]/+page.svelte
+++ b/src/routes/dashboard/stats/[[year]]/+page.svelte
@@ -29,7 +29,7 @@
   }
 </script>
 
-<div class="flex justify-between items-center m-2">
+<div class="flex justify-between items-center mb-4">
   <div>
     <button class="btn" onclick={previousYear}>
       <Fa icon={faArrowLeft} /><span>{$_('button.year')}</span>

--- a/src/routes/dashboard/stats/[[year]]/top/[category]/[section]/+page.svelte
+++ b/src/routes/dashboard/stats/[[year]]/top/[category]/[section]/+page.svelte
@@ -81,7 +81,7 @@
         <span>
           <a class="btn btn-sm preset-tonal-primary" href={'/dashboard/members/' + e.memberId}>
             <Fa icon={faGripLines} />
-            <span>{$_('button.view')}</span>
+            <span class="hidden sm:inline">{$_('button.view')}</span>
           </a>
         </span>
       </li>

--- a/src/routes/dashboard/stats/[[year]]/top/[category]/[section]/+page.svelte
+++ b/src/routes/dashboard/stats/[[year]]/top/[category]/[section]/+page.svelte
@@ -38,7 +38,7 @@
   }
 </script>
 
-<span class="flex justify-between">
+<span class="flex justify-between items-center mb-4">
   <h1>
     {#if data.category?.toLowerCase() == 'athletes'}
       {$_('page.stats.topAthletes')}
@@ -51,9 +51,13 @@
     {/if}
     {data.section}
   </h1>
-  <button type="button" class="btn-icon" onclick={downloadCsv}><Fa icon={faDownload} /></button>
+  <button
+    type="button"
+    class="btn btn-icon preset-tonal-surface min-w-[44px] min-h-[44px]"
+    onclick={downloadCsv}><Fa icon={faDownload} /></button
+  >
 </span>
-<div class="m-2">
+<div class="mb-4">
   <input
     class="input"
     bind:value={searchTerm}

--- a/src/routes/dashboard/trainings/+page.svelte
+++ b/src/routes/dashboard/trainings/+page.svelte
@@ -27,7 +27,7 @@
       </span>
       <a class="btn btn-sm preset-tonal-primary flex-shrink-0" href="/dashboard/trainings/{t.id}">
         <Fa icon={faGripLines} />
-        <span>{$_('button.view')}</span>
+        <span class="hidden sm:inline">{$_('button.view')}</span>
       </a>
     </li>
   {/each}

--- a/src/routes/dashboard/trainings/+page.svelte
+++ b/src/routes/dashboard/trainings/+page.svelte
@@ -7,8 +7,8 @@
   let { data }: { data: PageData } = $props();
 </script>
 
-<h1>{$_('page.trainings.title')}</h1>
-<ul class="flex flex-col gap-1">
+<h1 class="mb-4">{$_('page.trainings.title')}</h1>
+<ul class="flex flex-col gap-2">
   {#each data.trainings as t, index (t.id)}
     {#if index === 0 || t.weekday !== data.trainings[index - 1].weekday}
       <h3 class="text-lg font-semibold mt-4 mb-1">{$_('weekday.' + t.weekday)}</h3>

--- a/src/routes/dashboard/trainings/[trainingId]/+page.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/+page.svelte
@@ -21,7 +21,7 @@
     href="/dashboard/trainings/{data.id}/{getDateString()}"
   >
     <Fa icon={faClipboardCheck} />
-    <span>{$_('button.trackAttendance')}</span>
+    <span class="hidden sm:inline">{$_('button.trackAttendance')}</span>
   </a>
 </div>
 <div class="flex items-center gap-2 mb-6 flex-wrap text-sm">

--- a/src/routes/dashboard/trainings/[trainingId]/+page.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/+page.svelte
@@ -14,10 +14,10 @@
 </script>
 
 <!-- Header -->
-<div class="flex items-center justify-between mb-2">
+<div class="flex items-center justify-between mb-4">
   <h1>{data.title}</h1>
   <a
-    class="btn btn-sm preset-filled-primary-500 flex-none"
+    class="btn btn-sm preset-tonal-primary flex-none"
     href="/dashboard/trainings/{data.id}/{getDateString()}"
   >
     <Fa icon={faClipboardCheck} />

--- a/src/routes/dashboard/trainings/[trainingId]/[date]/+page.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/[date]/+page.svelte
@@ -249,7 +249,7 @@
   {/if}
 
   <!-- Search -->
-  <div class="mb-3">
+  <div class="mb-4">
     <input
       class="input"
       onkeydown={navigateList}
@@ -263,7 +263,7 @@
   </div>
 
   <!-- Participant list -->
-  <ul class="flex flex-col gap-1">
+  <ul class="flex flex-col gap-2">
     {#each filteredData as p (p.id)}
       <div
         class="item"

--- a/src/routes/dashboard/trainings/[trainingId]/[date]/+page.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/[date]/+page.svelte
@@ -168,7 +168,7 @@
 <div class="card p-4 mb-4">
   <div class="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
     <div>
-      <h2 class="h2">{data.title}</h2>
+      <h1>{data.title}</h1>
       <div class="flex items-center gap-2 mt-1">
         <span class="badge preset-tonal-secondary">{data.section}</span>
         <span class="text-sm opacity-70">

--- a/src/routes/dashboard/trainings/[trainingId]/[date]/AddParticipantInputBox.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/[date]/AddParticipantInputBox.svelte
@@ -189,7 +189,7 @@
   >
     <!-- svelte-ignore a11y_no_static_element_interactions -->
     <div
-      class="card p-6 w-full max-w-md shadow-2xl bg-surface-50-950"
+      class="card p-6 w-full max-w-lg shadow-2xl bg-surface-50-950"
       onclick={(e) => e.stopPropagation()}
     >
       <h3 class="font-semibold text-lg mb-4">{$_('button.createNew')}</h3>


### PR DESCRIPTION
Standardize spacing, touch targets, and visual patterns:
- Unify page header margins to mb-4 across all pages
- Unify search input margins to mb-4 across all pages
- Standardize list gaps to gap-2 for flat lists, gap-3 for card lists
- Add responsive breakpoints to event stats grid (sm:gap-4, sm:p-4, sm:text-xl)
- Increase touch targets on icon-only buttons to 44x44px minimum
- Add py-8 to dashboard empty state for consistent vertical spacing
- Standardize member detail card padding to p-4 (was p-6)
- Unify track attendance button preset to preset-tonal-primary
- Add min-w-0 to event detail title for proper text truncation
- Add items-center and mb-4 to stats detail page header

https://claude.ai/code/session_01Ka7xinmhN6PrZXLjNcek6w