### PR TITLE
Add CRUD operations for trainings

### DIFF
--- a/src/lib/i18n/locales/de.json
+++ b/src/lib/i18n/locales/de.json
@@ -69,7 +69,30 @@
       "textDisabledWhenFileSelected": "Textinhalt ist deaktiviert wenn eine Datei ausgewählt ist",
       "uploading": "Hochladen...",
       "uploadError": "Fehler beim Hochladen der Datei",
-      "saveError": "Fehler beim Speichern des Lektionsplans"
+      "saveError": "Fehler beim Speichern des Lektionsplans",
+      "create_training": "Training Erstellen",
+      "edit_training": "Training Bearbeiten",
+      "form": {
+        "title": "Trainingstitel",
+        "title_placeholder": "z.B. Kinder Judo, Fortgeschrittenes Aikido...",
+        "weekday": "Wochentag",
+        "select_weekday": "Wochentag auswählen...",
+        "time_from": "Startzeit",
+        "time_to": "Endzeit",
+        "section": "Sektion",
+        "select_section": "Sektion auswählen..."
+      },
+      "validation": {
+        "required_fields": "Bitte alle Pflichtfelder ausfüllen"
+      },
+      "createSuccess": "Training erfolgreich erstellt",
+      "createError": "Fehler beim Erstellen des Trainings",
+      "updateSuccess": "Training erfolgreich aktualisiert",
+      "updateError": "Fehler beim Aktualisieren des Trainings",
+      "deleteConfirmTitle": "Training Löschen",
+      "deleteConfirmMessage": "Sind Sie sicher, dass Sie das Training löschen möchten",
+      "deleteSuccess": "Training erfolgreich gelöscht",
+      "deleteError": "Fehler beim Löschen des Trainings"
     },
     "members": {
       "title": "Mitglieder",

--- a/src/lib/i18n/locales/en.json
+++ b/src/lib/i18n/locales/en.json
@@ -69,7 +69,30 @@
       "textDisabledWhenFileSelected": "Text content is disabled when a file is selected",
       "uploading": "Uploading...",
       "uploadError": "Error uploading file",
-      "saveError": "Error saving lesson plan"
+      "saveError": "Error saving lesson plan",
+      "create_training": "Create Training",
+      "edit_training": "Edit Training",
+      "form": {
+        "title": "Training Title",
+        "title_placeholder": "e.g. Kids Judo, Advanced Aikido...",
+        "weekday": "Weekday",
+        "select_weekday": "Select a weekday...",
+        "time_from": "Start Time",
+        "time_to": "End Time",
+        "section": "Section",
+        "select_section": "Select a section..."
+      },
+      "validation": {
+        "required_fields": "Please fill in all required fields"
+      },
+      "createSuccess": "Training created successfully",
+      "createError": "Error creating training",
+      "updateSuccess": "Training updated successfully",
+      "updateError": "Error updating training",
+      "deleteConfirmTitle": "Delete Training",
+      "deleteConfirmMessage": "Are you sure you want to delete the training",
+      "deleteSuccess": "Training successfully deleted",
+      "deleteError": "Error deleting training"
     },
     "members": {
       "title": "Members",

--- a/src/routes/dashboard/trainings/+page.svelte
+++ b/src/routes/dashboard/trainings/+page.svelte
@@ -1,13 +1,19 @@
 <script lang="ts">
   import type { PageData } from './$types';
   import Fa from 'svelte-fa';
-  import { faGripLines } from '@fortawesome/free-solid-svg-icons';
+  import { faGripLines, faPlus } from '@fortawesome/free-solid-svg-icons';
   import { _ } from 'svelte-i18n';
 
   let { data }: { data: PageData } = $props();
 </script>
 
-<h1 class="mb-4">{$_('page.trainings.title')}</h1>
+<div class="page-header">
+  <h1>{$_('page.trainings.title')}</h1>
+  <a href="/dashboard/trainings/new" class="btn preset-filled-primary-500">
+    <Fa icon={faPlus} />
+    <span>{$_('page.trainings.create_training')}</span>
+  </a>
+</div>
 <ul class="flex flex-col gap-2">
   {#each data.trainings as t, index (t.id)}
     {#if index === 0 || t.weekday !== data.trainings[index - 1].weekday}

--- a/src/routes/dashboard/trainings/[trainingId]/+page.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/+page.svelte
@@ -11,7 +11,8 @@
     faClipboardCheck,
     faArrowLeft,
     faEdit,
-    faTrash
+    faTrash,
+    faEllipsisVertical
   } from '@fortawesome/free-solid-svg-icons';
   import { supabaseClient } from '$lib/supabase';
   import { goto } from '$app/navigation';
@@ -19,6 +20,18 @@
 
   let isDeleting = $state(false);
   let showDeleteConfirm = $state(false);
+  let menuOpen = $state(false);
+  let menuBtnEl: HTMLButtonElement;
+
+  function toggleMenu() {
+    menuOpen = !menuOpen;
+  }
+
+  function handleWindowClick(e: MouseEvent) {
+    if (menuOpen && menuBtnEl && !menuBtnEl.contains(e.target as Node)) {
+      menuOpen = false;
+    }
+  }
 
   function getDateString() {
     const weekday = utils.weekdayToNumber(data.weekday);
@@ -58,6 +71,8 @@
   }
 </script>
 
+<svelte:window onclick={handleWindowClick} />
+
 <!-- Header -->
 <div class="page-header-back">
   <a href="/dashboard/trainings" class="btn preset-tonal-surface flex-shrink-0">
@@ -65,16 +80,29 @@
   </a>
   <h1 class="flex-1 min-w-0 truncate">{data.title}</h1>
   <div class="flex gap-2 flex-shrink-0">
-    <a class="btn preset-tonal-primary" href="/dashboard/trainings/{data.id}/{getDateString()}">
-      <Fa icon={faClipboardCheck} />
-      <span class="hidden sm:inline">{$_('button.trackAttendance')}</span>
-    </a>
     <a href="/dashboard/trainings/{data.id}/edit" class="btn preset-tonal-surface">
       <Fa icon={faEdit} />
     </a>
-    <button class="btn preset-tonal-error" onclick={confirmDelete} disabled={isDeleting}>
-      <Fa icon={faTrash} />
-    </button>
+    <div class="relative">
+      <button class="btn preset-tonal-surface" bind:this={menuBtnEl} onclick={toggleMenu}>
+        <Fa icon={faEllipsisVertical} />
+      </button>
+      {#if menuOpen}
+        <nav class="card absolute right-0 top-full mt-1 z-50 min-w-40 p-1 shadow-xl">
+          <button
+            class="btn w-full justify-start text-error-600-400"
+            onclick={() => {
+              menuOpen = false;
+              confirmDelete();
+            }}
+            disabled={isDeleting}
+          >
+            <Fa icon={faTrash} />
+            <span>{$_('button.delete')}</span>
+          </button>
+        </nav>
+      {/if}
+    </div>
   </div>
 </div>
 <div class="flex items-center gap-2 mb-6 flex-wrap text-sm">
@@ -88,6 +116,15 @@
     {$_('page.trainings.participants')}
   </span>
 </div>
+
+<!-- Track Attendance -->
+<a
+  class="btn preset-filled-primary-500 w-full mb-6"
+  href="/dashboard/trainings/{data.id}/{getDateString()}"
+>
+  <Fa icon={faClipboardCheck} />
+  <span>{$_('button.trackAttendance')}</span>
+</a>
 
 {#if showDeleteConfirm}
   <!-- svelte-ignore a11y_no_static_element_interactions -->

--- a/src/routes/dashboard/trainings/[trainingId]/+page.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/+page.svelte
@@ -97,7 +97,10 @@
         <Fa icon={faEllipsisVertical} />
       </button>
       {#if menuOpen}
-        <nav class="card min-w-48 p-1 shadow-xl" style={menuStyle}>
+        <nav
+          class="card min-w-48 p-1 shadow-xl bg-surface-50-950 border border-surface-300-700"
+          style={menuStyle}
+        >
           <button
             class="btn w-full justify-start text-error-600-400"
             onclick={() => {

--- a/src/routes/dashboard/trainings/[trainingId]/+page.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/+page.svelte
@@ -21,10 +21,19 @@
   let isDeleting = $state(false);
   let showDeleteConfirm = $state(false);
   let menuOpen = $state(false);
+  let menuStyle = $state('');
   let menuBtnEl: HTMLButtonElement;
 
   function toggleMenu() {
-    menuOpen = !menuOpen;
+    if (menuOpen) {
+      menuOpen = false;
+      return;
+    }
+    const rect = menuBtnEl.getBoundingClientRect();
+    const top = rect.bottom + 4;
+    const left = rect.right - 192;
+    menuStyle = `position:fixed;top:${top}px;left:${left}px;z-index:9999;`;
+    menuOpen = true;
   }
 
   function handleWindowClick(e: MouseEvent) {
@@ -88,7 +97,7 @@
         <Fa icon={faEllipsisVertical} />
       </button>
       {#if menuOpen}
-        <nav class="card absolute right-0 top-full mt-1 z-50 min-w-40 p-1 shadow-xl">
+        <nav class="card min-w-48 p-1 shadow-xl" style={menuStyle}>
           <button
             class="btn w-full justify-start text-error-600-400"
             onclick={() => {

--- a/src/routes/dashboard/trainings/[trainingId]/+page.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/+page.svelte
@@ -5,24 +5,77 @@
   import utils from '$lib/utils';
   import { _ } from 'svelte-i18n';
   import Fa from 'svelte-fa';
-  import { faClock, faUsers, faClipboardCheck } from '@fortawesome/free-solid-svg-icons';
+  import {
+    faClock,
+    faUsers,
+    faClipboardCheck,
+    faArrowLeft,
+    faEdit,
+    faTrash
+  } from '@fortawesome/free-solid-svg-icons';
+  import { supabaseClient } from '$lib/supabase';
+  import { goto } from '$app/navigation';
+  import { toaster } from '$lib/toast';
+
+  let isDeleting = $state(false);
+  let showDeleteConfirm = $state(false);
 
   function getDateString() {
     const weekday = utils.weekdayToNumber(data.weekday);
     return utils.getMostRecentDateByWeekday(weekday).format('YYYY-MM-DD');
   }
+
+  function confirmDelete() {
+    showDeleteConfirm = true;
+  }
+
+  async function handleDeleteResponse(confirmed: boolean) {
+    showDeleteConfirm = false;
+    if (!confirmed) return;
+
+    isDeleting = true;
+    try {
+      // Delete related records first
+      await supabaseClient.from('lesson_plans').delete().eq('trainingId', data.id);
+      await supabaseClient.from('logs').delete().eq('trainingId', data.id);
+      await supabaseClient.from('participants').delete().eq('trainingId', data.id);
+
+      // Delete the training
+      const { error } = await supabaseClient.from('trainings').delete().eq('id', data.id);
+
+      if (error) {
+        throw error;
+      }
+
+      toaster.success({ title: $_('page.trainings.deleteSuccess') });
+      await goto('/dashboard/trainings');
+    } catch (error) {
+      console.error('Error deleting training:', error);
+      toaster.error({ title: $_('page.trainings.deleteError') });
+    } finally {
+      isDeleting = false;
+    }
+  }
 </script>
 
 <!-- Header -->
-<div class="page-header">
-  <h1>{data.title}</h1>
-  <a
-    class="btn preset-tonal-primary flex-none"
-    href="/dashboard/trainings/{data.id}/{getDateString()}"
-  >
-    <Fa icon={faClipboardCheck} />
-    <span class="hidden sm:inline">{$_('button.trackAttendance')}</span>
+<div class="page-header-back">
+  <a href="/dashboard/trainings" class="btn preset-tonal-surface flex-shrink-0">
+    <Fa icon={faArrowLeft} />
   </a>
+  <h1 class="flex-1 min-w-0 truncate">{data.title}</h1>
+  <div class="flex gap-2 flex-shrink-0">
+    <a class="btn preset-tonal-primary" href="/dashboard/trainings/{data.id}/{getDateString()}">
+      <Fa icon={faClipboardCheck} />
+      <span class="hidden sm:inline">{$_('button.trackAttendance')}</span>
+    </a>
+    <a href="/dashboard/trainings/{data.id}/edit" class="btn preset-tonal-surface">
+      <Fa icon={faEdit} />
+    </a>
+    <button class="btn preset-tonal-error" onclick={confirmDelete} disabled={isDeleting}>
+      <Fa icon={faTrash} />
+    </button>
+  </div>
 </div>
 <div class="flex items-center gap-2 mb-6 flex-wrap text-sm">
   <span class="chip preset-tonal-secondary">{data.section}</span>
@@ -35,6 +88,31 @@
     {$_('page.trainings.participants')}
   </span>
 </div>
+
+{#if showDeleteConfirm}
+  <!-- svelte-ignore a11y_no_static_element_interactions -->
+  <div
+    class="modal-overlay"
+    onclick={() => handleDeleteResponse(false)}
+    onkeydown={(e) => {
+      if (e.key === 'Escape') handleDeleteResponse(false);
+    }}
+  >
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div class="card modal-dialog" onclick={(e) => e.stopPropagation()}>
+      <h3>{$_('page.trainings.deleteConfirmTitle')}</h3>
+      <p class="mb-4">{$_('page.trainings.deleteConfirmMessage')} "{data.title}"?</p>
+      <div class="flex justify-end gap-2">
+        <button class="btn preset-tonal-surface" onclick={() => handleDeleteResponse(false)}>
+          {$_('button.cancel')}
+        </button>
+        <button class="btn preset-filled-error-500" onclick={() => handleDeleteResponse(true)}>
+          {$_('button.delete')}
+        </button>
+      </div>
+    </div>
+  </div>
+{/if}
 
 <!-- Logs section -->
 <h3>{$_('page.trainings.logs')}</h3>

--- a/src/routes/dashboard/trainings/[trainingId]/edit/+page.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/edit/+page.svelte
@@ -1,0 +1,148 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+  import { supabaseClient } from '$lib/supabase';
+  import { goto, invalidateAll } from '$app/navigation';
+  import { _ } from 'svelte-i18n';
+  import Fa from 'svelte-fa';
+  import { faSave, faArrowLeft } from '@fortawesome/free-solid-svg-icons';
+
+  let { data }: { data: PageData } = $props();
+
+  let title = $state(data.title);
+  let weekday = $state(data.weekday);
+  let dateFrom = $state(data.dateFrom);
+  let dateTo = $state(data.dateTo || '');
+  let section = $state(data.section);
+  let loading = $state(false);
+  let error = $state('');
+
+  const sections = ['Judo', 'Aikido'];
+  const weekdays = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+
+  async function updateTraining() {
+    if (!title || !weekday || !dateFrom || !section) {
+      error = $_('page.trainings.validation.required_fields');
+      return;
+    }
+
+    loading = true;
+    error = '';
+
+    try {
+      const { error: updateError } = await supabaseClient
+        .from('trainings')
+        .update({
+          title,
+          weekday,
+          dateFrom,
+          dateTo: dateTo || null,
+          section
+        })
+        .eq('id', data.id);
+
+      if (updateError) {
+        error = updateError.message;
+        return;
+      }
+
+      await invalidateAll();
+      await goto(`/dashboard/trainings/${data.id}`);
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Unknown error occurred';
+    } finally {
+      loading = false;
+    }
+  }
+</script>
+
+<div class="page-header-back">
+  <a href="/dashboard/trainings/{data.id}" class="btn preset-tonal-surface">
+    <Fa icon={faArrowLeft} />
+  </a>
+  <h1>{$_('page.trainings.edit_training')}</h1>
+</div>
+
+<form
+  onsubmit={(e: SubmitEvent) => {
+    e.preventDefault();
+    updateTraining();
+  }}
+  class="space-y-6"
+>
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6">
+    <!-- Title -->
+    <div class="md:col-span-2">
+      <label class="label" for="title">
+        <span>{$_('page.trainings.form.title')} *</span>
+      </label>
+      <input
+        id="title"
+        type="text"
+        class="input"
+        bind:value={title}
+        required
+        placeholder={$_('page.trainings.form.title_placeholder')}
+      />
+    </div>
+
+    <!-- Weekday -->
+    <div>
+      <label class="label" for="weekday">
+        <span>{$_('page.trainings.form.weekday')} *</span>
+      </label>
+      <select id="weekday" class="select" bind:value={weekday} required>
+        <option value="">{$_('page.trainings.form.select_weekday')}</option>
+        {#each weekdays as w}
+          <option value={w}>{$_('weekday.' + w)}</option>
+        {/each}
+      </select>
+    </div>
+
+    <!-- Section -->
+    <div>
+      <label class="label" for="section">
+        <span>{$_('page.trainings.form.section')} *</span>
+      </label>
+      <select id="section" class="select" bind:value={section} required>
+        <option value="">{$_('page.trainings.form.select_section')}</option>
+        {#each sections as s}
+          <option value={s}>{s}</option>
+        {/each}
+      </select>
+    </div>
+
+    <!-- Time From -->
+    <div>
+      <label class="label" for="dateFrom">
+        <span>{$_('page.trainings.form.time_from')} *</span>
+      </label>
+      <input id="dateFrom" type="time" class="input" bind:value={dateFrom} required />
+    </div>
+
+    <!-- Time To -->
+    <div>
+      <label class="label" for="dateTo">
+        <span>{$_('page.trainings.form.time_to')}</span>
+      </label>
+      <input id="dateTo" type="time" class="input" bind:value={dateTo} />
+    </div>
+  </div>
+
+  {#if error}
+    <div class="flex items-center gap-4 p-4 rounded-lg preset-filled-error-500">
+      <div class="flex-1">
+        <p>{error}</p>
+      </div>
+    </div>
+  {/if}
+
+  <div class="flex justify-end gap-4">
+    <a href="/dashboard/trainings/{data.id}" class="btn preset-tonal-surface">
+      {$_('button.cancel')}
+    </a>
+    <button type="submit" class="btn preset-filled-primary-500" disabled={loading}>
+      <Fa icon={faSave} />
+      <span>{loading ? $_('button.saving') : $_('button.save')}</span>
+    </button>
+  </div>
+</form>

--- a/src/routes/dashboard/trainings/new/+page.svelte
+++ b/src/routes/dashboard/trainings/new/+page.svelte
@@ -1,0 +1,145 @@
+<script lang="ts">
+  import { supabaseClient } from '$lib/supabase';
+  import { goto } from '$app/navigation';
+  import { _ } from 'svelte-i18n';
+  import Fa from 'svelte-fa';
+  import { faSave, faArrowLeft } from '@fortawesome/free-solid-svg-icons';
+
+  let title = $state('');
+  let weekday = $state('');
+  let dateFrom = $state('');
+  let dateTo = $state('');
+  let section = $state('');
+  let loading = $state(false);
+  let error = $state('');
+
+  const sections = ['Judo', 'Aikido'];
+  const weekdays = ['Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday'];
+
+  async function createTraining() {
+    if (!title || !weekday || !dateFrom || !section) {
+      error = $_('page.trainings.validation.required_fields');
+      return;
+    }
+
+    loading = true;
+    error = '';
+
+    try {
+      const { error: insertError, data } = await supabaseClient
+        .from('trainings')
+        .insert({
+          title,
+          weekday,
+          dateFrom,
+          dateTo: dateTo || null,
+          section
+        })
+        .select()
+        .single();
+
+      if (insertError) {
+        error = insertError.message;
+        return;
+      }
+
+      await goto(`/dashboard/trainings/${data.id}`);
+    } catch (e) {
+      error = e instanceof Error ? e.message : 'Unknown error occurred';
+    } finally {
+      loading = false;
+    }
+  }
+</script>
+
+<div class="page-header-back">
+  <a href="/dashboard/trainings" class="btn preset-tonal-surface">
+    <Fa icon={faArrowLeft} />
+  </a>
+  <h1>{$_('page.trainings.create_training')}</h1>
+</div>
+
+<form
+  onsubmit={(e: SubmitEvent) => {
+    e.preventDefault();
+    createTraining();
+  }}
+  class="space-y-6"
+>
+  <div class="grid grid-cols-1 md:grid-cols-2 gap-4 sm:gap-6">
+    <!-- Title -->
+    <div class="md:col-span-2">
+      <label class="label" for="title">
+        <span>{$_('page.trainings.form.title')} *</span>
+      </label>
+      <input
+        id="title"
+        type="text"
+        class="input"
+        bind:value={title}
+        required
+        placeholder={$_('page.trainings.form.title_placeholder')}
+      />
+    </div>
+
+    <!-- Weekday -->
+    <div>
+      <label class="label" for="weekday">
+        <span>{$_('page.trainings.form.weekday')} *</span>
+      </label>
+      <select id="weekday" class="select" bind:value={weekday} required>
+        <option value="">{$_('page.trainings.form.select_weekday')}</option>
+        {#each weekdays as w}
+          <option value={w}>{$_('weekday.' + w)}</option>
+        {/each}
+      </select>
+    </div>
+
+    <!-- Section -->
+    <div>
+      <label class="label" for="section">
+        <span>{$_('page.trainings.form.section')} *</span>
+      </label>
+      <select id="section" class="select" bind:value={section} required>
+        <option value="">{$_('page.trainings.form.select_section')}</option>
+        {#each sections as s}
+          <option value={s}>{s}</option>
+        {/each}
+      </select>
+    </div>
+
+    <!-- Time From -->
+    <div>
+      <label class="label" for="dateFrom">
+        <span>{$_('page.trainings.form.time_from')} *</span>
+      </label>
+      <input id="dateFrom" type="time" class="input" bind:value={dateFrom} required />
+    </div>
+
+    <!-- Time To -->
+    <div>
+      <label class="label" for="dateTo">
+        <span>{$_('page.trainings.form.time_to')}</span>
+      </label>
+      <input id="dateTo" type="time" class="input" bind:value={dateTo} />
+    </div>
+  </div>
+
+  {#if error}
+    <div class="flex items-center gap-4 p-4 rounded-lg preset-filled-error-500">
+      <div class="flex-1">
+        <p>{error}</p>
+      </div>
+    </div>
+  {/if}
+
+  <div class="flex justify-end gap-4">
+    <a href="/dashboard/trainings" class="btn preset-tonal-surface">
+      {$_('button.cancel')}
+    </a>
+    <button type="submit" class="btn preset-filled-primary-500" disabled={loading}>
+      <Fa icon={faSave} />
+      <span>{loading ? $_('button.creating') : $_('button.create')}</span>
+    </button>
+  </div>
+</form>


### PR DESCRIPTION
Add create, edit, and delete functionality for trainings, matching the
existing patterns used by events and members.

- Add /dashboard/trainings/new page with form for title, weekday, section, times
- Add /dashboard/trainings/[trainingId]/edit page with pre-populated form
- Add edit/delete buttons to training detail page with confirmation modal
- Add "Create Training" button to trainings list page
- Add i18n keys for both en and de locales

https://claude.ai/code/session_01X4doPp22j16VYJVd4ePJxW