### PR TITLE
Move member badge from avatar overlay to name suffix

### DIFF
--- a/src/routes/dashboard/members/+page.svelte
+++ b/src/routes/dashboard/members/+page.svelte
@@ -120,8 +120,10 @@
         <span class="list-item-content">
           <dt class="font-bold truncate">
             {m.lastname}
-            {m.firstname}{#if data.badgeMap[m.id]}
-              {data.badgeMap[m.id]}{/if}
+            {m.firstname}{#if data.badgeMap[m.id]}<span
+                class="ml-1 inline-block text-base leading-none align-middle"
+                >{data.badgeMap[m.id]}</span
+              >{/if}
           </dt>
           <dd class="flex flex-wrap gap-1">
             {#if m.labels}

--- a/src/routes/dashboard/members/+page.svelte
+++ b/src/routes/dashboard/members/+page.svelte
@@ -113,17 +113,16 @@
     {#if search(m.firstname, m.lastname)}
       <li class="list-item">
         <div class="relative inline-block flex-shrink-0">
-          {#if data.badgeMap[m.id]}
-            <span class="absolute -top-0.5 -left-0.5 z-10 text-xs leading-none">
-              {data.badgeMap[m.id]}
-            </span>
-          {/if}
           <div class="avatar-initials">
             {m.lastname.charAt(0)}{m.firstname.charAt(0)}
           </div>
         </div>
         <span class="list-item-content">
-          <dt class="font-bold truncate">{m.lastname} {m.firstname}</dt>
+          <dt class="font-bold truncate">
+            {m.lastname}
+            {m.firstname}{#if data.badgeMap[m.id]}
+              {data.badgeMap[m.id]}{/if}
+          </dt>
           <dd class="flex flex-wrap gap-1">
             {#if m.labels}
               {#each m.labels as l (l)}

--- a/src/routes/dashboard/trainings/[trainingId]/[date]/ParticipantCard.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/[date]/ParticipantCard.svelte
@@ -114,8 +114,9 @@
     <span class="list-item-content">
       <dt class="truncate">
         {member.lastname}
-        {member.firstname}{#if badgeEmoji}
-          {badgeEmoji}{/if}
+        {member.firstname}{#if badgeEmoji}<span
+            class="ml-1 inline-block text-base leading-none align-middle">{badgeEmoji}</span
+          >{/if}
       </dt>
       <dd class="flex items-center gap-2 flex-wrap">
         <Labels labels={member.labels ? member.labels : []} />

--- a/src/routes/dashboard/trainings/[trainingId]/[date]/ParticipantCard.svelte
+++ b/src/routes/dashboard/trainings/[trainingId]/[date]/ParticipantCard.svelte
@@ -86,11 +86,6 @@
       onchange={change}
     />
     <div class="relative inline-block flex-shrink-0">
-      {#if badgeEmoji}
-        <span class="absolute -top-0.5 -left-0.5 z-10 text-xs leading-none">
-          {badgeEmoji}
-        </span>
-      {/if}
       {#if member.trainerRole === 'main_trainer'}
         <span
           class="absolute -bottom-0 -right-0 z-10 bg-primary-600-400 rounded-full w-4 h-4 flex items-center justify-center"
@@ -117,7 +112,11 @@
       {/if}
     </div>
     <span class="list-item-content">
-      <dt class="truncate">{member.lastname} {member.firstname}</dt>
+      <dt class="truncate">
+        {member.lastname}
+        {member.firstname}{#if badgeEmoji}
+          {badgeEmoji}{/if}
+      </dt>
       <dd class="flex items-center gap-2 flex-wrap">
         <Labels labels={member.labels ? member.labels : []} />
         <ParticipantFrequency streak={member.streak} isPresent={member.isPresent} />


### PR DESCRIPTION
The badge emoji is now appended after the member's name instead of being
rendered as an overlay on top of the avatar/initials, making it more
legible and avoiding visual clutter on the display image.

https://claude.ai/code/session_01EEby1EUMWqiVvXTor4y4c7